### PR TITLE
chore: remove @shadcn/ui dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
-    "@shadcn/ui": "^0.8.0",
     "@testing-library/jest-dom": "^6.4.2",
     "@testing-library/react": "^14.3.1",
     "@testing-library/user-event": "^14.5.2",


### PR DESCRIPTION
## Summary
- remove the `@shadcn/ui` entry from devDependencies so the project no longer references an unpublished version

## Testing
- pnpm install *(fails with ERR_PNPM_FETCH_403 fetching @testing-library/user-event due to missing registry auth)*
- npm install *(fails with E403 fetching @hookform/resolvers due to missing registry auth)*

------
https://chatgpt.com/codex/tasks/task_e_68e0ed8710fc8331bf6fab2a9b9b468a