### PR TITLE
Remove deprecated serverActions flag from Next config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,8 +1,5 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  experimental: {
-    serverActions: true
-  },
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
## Summary
- remove the experimental.serverActions flag from the Next.js configuration

## Testing
- npm run build *(fails: next command unavailable because dependencies are not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0ef2b02c08331aa11d68bec5c5242