### PR TITLE
chore: remove supabase proxy module

### DIFF
--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,2 +1,0 @@
-export { createSupabaseServerClient } from './supabase-server';
-export { createSupabaseBrowserClient } from './supabase-browser';


### PR DESCRIPTION
## Summary
- remove the lib/supabase.ts re-export so client bundles no longer pull in server-only dependencies

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e0f1d16a5c8331818c260e1e2448ea