### PR TITLE
refactor: centralize supabase config for helpers

### DIFF
--- a/lib/supabase-browser.ts
+++ b/lib/supabase-browser.ts
@@ -1,9 +1,10 @@
 import { createBrowserClient } from '@supabase/auth-helpers-nextjs';
+import { supabaseConfig } from './supabase-env';
 import { type Database } from '@/types/database';
 
 export function createSupabaseBrowserClient() {
   return createBrowserClient<Database>(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    supabaseConfig.url,
+    supabaseConfig.anonKey
   );
 }

--- a/lib/supabase-env.ts
+++ b/lib/supabase-env.ts
@@ -1,0 +1,15 @@
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+if (!url) {
+  throw new Error('NEXT_PUBLIC_SUPABASE_URL is not defined');
+}
+
+if (!anonKey) {
+  throw new Error('NEXT_PUBLIC_SUPABASE_ANON_KEY is not defined');
+}
+
+export const supabaseConfig = {
+  url,
+  anonKey
+};

--- a/lib/supabase-server.ts
+++ b/lib/supabase-server.ts
@@ -1,14 +1,15 @@
 import { cookies } from 'next/headers';
 import { createServerClient } from '@supabase/auth-helpers-nextjs';
 import { type CookieOptions } from '@supabase/auth-helpers-shared';
+import { supabaseConfig } from './supabase-env';
 import { type Database } from '@/types/database';
 
 export function createSupabaseServerClient() {
   const cookieStore = cookies();
 
   return createServerClient<Database>(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    supabaseConfig.url,
+    supabaseConfig.anonKey,
     {
       cookies: {
         get(name: string) {


### PR DESCRIPTION
## Summary
- add a shared supabase config helper that validates required environment variables
- update the browser and server Supabase clients to consume the shared configuration

## Testing
- npm run lint *(fails: Failed to load config "prettier" to extend from.)*

------
https://chatgpt.com/codex/tasks/task_e_68e0f40302708331b3b69b3e513cdd73