### PR TITLE
Refine Supabase server utilities

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,5 +1,4 @@
-import { cookies } from 'next/headers';
-import { createSupabaseServerClient } from './supabase-server';
+import { clearSupabaseAuthCookies, createSupabaseServerClient } from './supabase-server';
 
 export async function getSession() {
   const supabase = createSupabaseServerClient();
@@ -32,6 +31,5 @@ export async function requireRole(required: 'USER' | 'PROVIDER' | 'ADMIN') {
 export async function signOutServer() {
   const supabase = createSupabaseServerClient();
   await supabase.auth.signOut();
-  cookies().delete('sb-access-token');
-  cookies().delete('sb-refresh-token');
+  clearSupabaseAuthCookies();
 }

--- a/lib/supabase-server.ts
+++ b/lib/supabase-server.ts
@@ -25,3 +25,9 @@ export function createSupabaseServerClient() {
     }
   );
 }
+
+export function clearSupabaseAuthCookies() {
+  const cookieStore = cookies();
+  cookieStore.delete('sb-access-token');
+  cookieStore.delete('sb-refresh-token');
+}


### PR DESCRIPTION
## Summary
- centralize server-side Supabase cookie handling in lib/supabase-server
- update auth helper to use the new cookie clearing helper

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e104cf10c0833197ee69b518a5ec9c